### PR TITLE
Make navigation links black

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -55,7 +55,7 @@ nav ul{
 nav ul  a{
   font-family:  sans-serif;
   line-height: 4rem;
-  color: #5EAAA8;
+  color: black;
   padding-top: 12px ;
   padding-bottom:  12px ;
   transition: .3s;
@@ -66,7 +66,7 @@ nav ul  a{
 }
 
 nav ul  a:hover{
-  color: #056676;
+  color: black;
 }
 
 nav{


### PR DESCRIPTION
## Summary
- update navigation link colors to black for About, Work, and Contact items

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a5645403ac83239d440921afd4b498